### PR TITLE
Refactor options caching

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -15,15 +15,18 @@ module MultiJson
     end
 
     def fetch(type, key, &)
-      cache = instance_variable_get("@#{type}_cache")
-      unless cache
-        reset
-        cache = instance_variable_get("@#{type}_cache")
-      end
-      cache.key?(key) ? cache[key] : write(cache, key, &)
+      cache = cache_for(type)
+      cache.fetch(key) { write(cache, key, &) }
     end
 
     private
+
+    def cache_for(type)
+      instance_variable_get("@#{type}_cache") || begin
+        reset
+        instance_variable_get("@#{type}_cache")
+      end
+    end
 
     def write(cache, key)
       cache.clear if cache.length >= MAX_CACHE_SIZE

--- a/spec/shared/adapter.rb
+++ b/spec/shared/adapter.rb
@@ -15,7 +15,7 @@ shared_examples_for "an adapter" do |adapter|
   describe ".dump" do
     let(:json_pure) do
       Kernel.const_get("MultiJson::Adapters::JsonPure")
-    rescue StandardError
+    rescue
       nil
     end
 


### PR DESCRIPTION
## Summary
- clean up OptionsCache#fetch by adding a helper method
- drop `StandardError` from a rescue clause in tests

## Testing
- `bundle exec rake spec`
- `bundle exec standardrb`

------
https://chatgpt.com/codex/tasks/task_e_685b043f5b5083279e9895804e13ef1d