### PR TITLE
Improve default adapter warning

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -43,10 +43,13 @@ module MultiJson
     adapter = loaded_adapter || installable_adapter
     return adapter if adapter
 
-    Kernel.warn(
-      "[WARNING] MultiJson is using the default adapter (ok_json). " \
-      "We recommend loading a different JSON library to improve performance."
-    )
+    unless defined?(@default_adapter_warning_shown) && @default_adapter_warning_shown
+      Kernel.warn(
+        "[WARNING] MultiJson is using the default adapter (ok_json). " \
+        "We recommend loading a different JSON library to improve performance."
+      )
+      @default_adapter_warning_shown = true
+    end
 
     :ok_json
   end

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe MultiJson do
       simulate_no_adapters { example.call }
     end
 
+    before do
+      if described_class.instance_variable_defined?(:@default_adapter_warning_shown)
+        described_class.remove_instance_variable(:@default_adapter_warning_shown)
+      end
+    end
+
+    after do
+      if described_class.instance_variable_defined?(:@default_adapter_warning_shown)
+        described_class.remove_instance_variable(:@default_adapter_warning_shown)
+      end
+    end
+
     it "defaults to ok_json if no other json implementions are available" do
       silence_warnings do
         expect(described_class.default_adapter).to eq(:ok_json)
@@ -26,6 +38,12 @@ RSpec.describe MultiJson do
 
     it "prints a warning" do
       expect(Kernel).to receive(:warn).with(/warning/i)
+      described_class.default_adapter
+    end
+
+    it "warns only once" do
+      expect(Kernel).to receive(:warn).once
+      described_class.default_adapter
       described_class.default_adapter
     end
   end


### PR DESCRIPTION
## Summary
- avoid repeated warnings when falling back to the default adapter
- test that the warning is emitted only once

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_685b043f5b5083279e9895804e13ef1d