### PR TITLE
Improve encapsulation of internal constants

### DIFF
--- a/lib/multi_json/adapters/json_common.rb
+++ b/lib/multi_json/adapters/json_common.rb
@@ -11,6 +11,7 @@ module MultiJson
         object_nl: "\n",
         array_nl: "\n"
       }.freeze
+      private_constant :PRETTY_STATE_PROTOTYPE
 
       def load(string, options = {})
         string = string.dup.force_encoding(::Encoding::ASCII_8BIT) if string.respond_to?(:force_encoding)

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -17,6 +17,7 @@ module MultiJson
       # (at least for now).
       class ParseError < ::SyntaxError
         WRAPPED_CLASSES = %w[Oj::ParseError JSON::ParserError].to_set.freeze
+        private_constant :WRAPPED_CLASSES
 
         def self.===(exception)
           case exception
@@ -36,6 +37,7 @@ module MultiJson
       OJ_VERSION = ::Oj::VERSION
       OJ_V2 = OJ_VERSION.start_with?("2.")
       OJ_V3 = OJ_VERSION.start_with?("3.")
+      private_constant :OJ_VERSION, :OJ_V2, :OJ_V3
 
       if OJ_V3
         PRETTY_STATE_PROTOTYPE = {
@@ -46,6 +48,7 @@ module MultiJson
           array_nl: "\n",
           ascii_only: false
         }.freeze
+        private_constant :PRETTY_STATE_PROTOTYPE
       end
 
       def dump(object, options = {})

--- a/lib/multi_json/convertible_hash_keys.rb
+++ b/lib/multi_json/convertible_hash_keys.rb
@@ -1,6 +1,7 @@
 module MultiJson
   module ConvertibleHashKeys
     SIMPLE_OBJECT_CLASSES = [String, Numeric, TrueClass, FalseClass, NilClass].freeze
+    private_constant :SIMPLE_OBJECT_CLASSES
 
     private
 


### PR DESCRIPTION
## Summary
- mark `SIMPLE_OBJECT_CLASSES` as private
- mark adapter formatting constants as private

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_685b07c89a98832787714cf5e89d4557