### PR TITLE
Improve exception chaining

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -96,7 +96,7 @@ module MultiJson
       raise ::LoadError, new_adapter
     end
   rescue ::LoadError => e
-    raise AdapterError.build(e)
+    raise(AdapterError.build(e), cause: e)
   end
 
   # Decode a JSON string into Ruby.
@@ -110,7 +110,7 @@ module MultiJson
     begin
       adapter.load(string, options)
     rescue adapter::ParseError => e
-      raise ParseError.build(e, string)
+      raise(ParseError.build(e, string), cause: e)
     end
   end
   alias_method :decode, :load

--- a/lib/multi_json/adapter_error.rb
+++ b/lib/multi_json/adapter_error.rb
@@ -1,10 +1,7 @@
 module MultiJson
   class AdapterError < ArgumentError
-    attr_reader :cause
-
     def initialize(message = nil, cause: nil)
       super(message)
-      @cause = cause
       set_backtrace(cause.backtrace) if cause
     end
 

--- a/lib/multi_json/parse_error.rb
+++ b/lib/multi_json/parse_error.rb
@@ -1,11 +1,10 @@
 module MultiJson
   class ParseError < StandardError
-    attr_reader :data, :cause
+    attr_reader :data
 
     def initialize(message = nil, data: nil, cause: nil)
       super(message)
       @data = data
-      @cause = cause
       set_backtrace(cause.backtrace) if cause
     end
 


### PR DESCRIPTION
## Summary
- update `ParseError` and `AdapterError` to rely on Ruby's built‑in exception chaining
- propagate the original exception using `raise(..., cause: e)`

## Testing
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_685b0f03aa108327a4302cc0d26abe42