### PR TITLE
Stop setting defaults in JsonCommon

### DIFF
--- a/lib/multi_json/adapter.rb
+++ b/lib/multi_json/adapter.rb
@@ -11,7 +11,8 @@ module MultiJson
       private_constant :BLANK_RE
 
       def defaults(action, value)
-        define_singleton_method("default_#{action}_options") { value.freeze }
+        value.freeze
+        define_singleton_method("default_#{action}_options") { value }
       end
 
       def load(string, options = {})

--- a/lib/multi_json/adapters/json_common.rb
+++ b/lib/multi_json/adapters/json_common.rb
@@ -3,8 +3,6 @@ require_relative "../adapter"
 module MultiJson
   module Adapters
     class JsonCommon < Adapter
-      defaults :load, create_additions: false, quirks_mode: true
-
       PRETTY_STATE_PROTOTYPE = {
         indent: "  ",
         space: " ",

--- a/spec/shared/json_common_adapter.rb
+++ b/spec/shared/json_common_adapter.rb
@@ -25,11 +25,4 @@ shared_examples_for "JSON-like adapter" do |adapter|
       end
     end
   end
-
-  describe ".load" do
-    it "passes :quirks_mode option" do
-      expect(JSON).to receive(:parse).with("[123]", {quirks_mode: false, create_additions: false})
-      MultiJson.load("[123]", quirks_mode: false)
-    end
-  end
 end


### PR DESCRIPTION
`quirks_mode` has been removed from the json gem in 2016: https://github.com/ruby/json/commit/7d2ad6d6556da03300a5aeadeeacaec563435773

`create_additions` is false by default when calling `JSON.parse` since forever, it's only true by default when calling `JSON.load` (and that too is chaning in the future).