### PR TITLE
Revert breaking changes from 1.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', 'jruby']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby-9.4', 'jruby-10.0']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
   Exclude:
     - "lib/multi_json/vendor/**/*.rb"
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.0
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,2 +1,3 @@
+ruby_version: 3.0
 ignore:
   - "lib/multi_json/vendor/**/*.rb"

--- a/README.md
+++ b/README.md
@@ -59,10 +59,13 @@ MultiJSON falls back to [OkJson][], a simple, vendorable JSON parser.
 This library aims to support and is [tested against](https://github.com/sferik/multi_json/actions/workflows/ci.yml) the following Ruby
 implementations:
 
+- Ruby 3.0
+- Ruby 3.1
 - Ruby 3.2
 - Ruby 3.3
 - Ruby 3.4
-- [JRuby 10][jruby]
+- [JRuby][jruby] 9.4 (targets Ruby 3.1 compatibility)
+- [JRuby][jruby] 10.0 (targets Ruby 3.4 compatibility)
 
 If something doesn't work in one of these implementations, it's a bug.
 

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -1,5 +1,4 @@
 require "oj"
-require "set"
 require_relative "../adapter"
 
 module MultiJson
@@ -17,7 +16,7 @@ module MultiJson
       # shouldn't be a problem since the library is not known to be using it
       # (at least for now).
       class ParseError < ::SyntaxError
-        WRAPPED_CLASSES = %w[Oj::ParseError JSON::ParserError].to_set.freeze
+        WRAPPED_CLASSES = %w[Oj::ParseError JSON::ParserError].freeze
         private_constant :WRAPPED_CLASSES
 
         def self.===(exception)

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -1,4 +1,5 @@
 require "oj"
+require "set"
 require_relative "../adapter"
 
 module MultiJson

--- a/lib/multi_json/convertible_hash_keys.rb
+++ b/lib/multi_json/convertible_hash_keys.rb
@@ -17,12 +17,12 @@ module MultiJson
       end
     end
 
-    def prepare_hash(value, &)
+    def prepare_hash(value, &block)
       case value
       when Array
-        handle_array(value, &)
+        handle_array(value, &block)
       when Hash
-        handle_hash(value, &)
+        handle_hash(value, &block)
       else
         handle_simple_objects(value)
       end

--- a/lib/multi_json/options.rb
+++ b/lib/multi_json/options.rb
@@ -10,12 +10,12 @@ module MultiJson
       @dump_options = options
     end
 
-    def load_options(*)
-      (defined?(@load_options) && get_options(@load_options, *)) || default_load_options
+    def load_options(*args)
+      (defined?(@load_options) && get_options(@load_options, *args)) || default_load_options
     end
 
-    def dump_options(*)
-      (defined?(@dump_options) && get_options(@dump_options, *)) || default_dump_options
+    def dump_options(*args)
+      (defined?(@dump_options) && get_options(@dump_options, *args)) || default_dump_options
     end
 
     def default_load_options
@@ -28,8 +28,8 @@ module MultiJson
 
     private
 
-    def get_options(options, *)
-      return handle_callable_options(options, *) if options_callable?(options)
+    def get_options(options, *args)
+      return handle_callable_options(options, *args) if options_callable?(options)
 
       handle_hashable_options(options)
     end
@@ -38,8 +38,8 @@ module MultiJson
       options.respond_to?(:call)
     end
 
-    def handle_callable_options(options, *)
-      options.arity.zero? ? options.call : options.call(*)
+    def handle_callable_options(options, *args)
+      options.arity.zero? ? options.call : options.call(*args)
     end
 
     def handle_hashable_options(options)

--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -20,7 +20,7 @@ module MultiJson
         end
       end
 
-      def fetch(key, &)
+      def fetch(key, &block)
         @mutex.synchronize do
           return @cache[key] if @cache.key?(key)
         end

--- a/multi_json.gemspec
+++ b/multi_json.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.name = "multi_json"
   spec.require_path = "lib"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.0"
   spec.summary = "A common interface to multiple JSON libraries."
   spec.version = MultiJson::Version
 


### PR DESCRIPTION
As discussed in #9, backward incompatible changes require a new major version.  This PR revert these changes to make sure the code works on Ruby 3.0 (as the previous minor version of the gem), so that we can tag a new minor version with the fixes (1.17.0).

These commits can then be reverted to drop support for older versions of Ruby and release a new major version of the gem (2.0.0).