### PR TITLE
Run a linter before testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true
+    - name: Run linter
+      run: bundle exec rake standard
+
   test:
     strategy:
       matrix:
         ruby-version: ['3.2', '3.3', '3.4', 'jruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
+    needs: lint
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The project has a development dependency on standard, but it is not run
during CI, making it easy to introduce unoticed style errors.

Add a CI step before running the actual tests to ensure the code style
is as expected.
