### PR TITLE
Bring back support for Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', 'jruby']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -16,7 +16,7 @@ module MultiJson
       # shouldn't be a problem since the library is not known to be using it
       # (at least for now).
       class ParseError < ::SyntaxError
-        WRAPPED_CLASSES = %w[Oj::ParseError JSON::ParserError].to_set.freeze
+        WRAPPED_CLASSES = %w[Oj::ParseError JSON::ParserError].freeze
         private_constant :WRAPPED_CLASSES
 
         def self.===(exception)

--- a/lib/multi_json/convertible_hash_keys.rb
+++ b/lib/multi_json/convertible_hash_keys.rb
@@ -17,12 +17,12 @@ module MultiJson
       end
     end
 
-    def prepare_hash(value, &)
+    def prepare_hash(value, &_block)
       case value
       when Array
-        handle_array(value, &)
+        handle_array(value, &_block)
       when Hash
-        handle_hash(value, &)
+        handle_hash(value, &_block)
       else
         handle_simple_objects(value)
       end

--- a/lib/multi_json/options.rb
+++ b/lib/multi_json/options.rb
@@ -10,12 +10,12 @@ module MultiJson
       @dump_options = options
     end
 
-    def load_options(*)
-      (defined?(@load_options) && get_options(@load_options, *)) || default_load_options
+    def load_options(*args)
+      (defined?(@load_options) && get_options(@load_options, *args)) || default_load_options
     end
 
-    def dump_options(*)
-      (defined?(@dump_options) && get_options(@dump_options, *)) || default_dump_options
+    def dump_options(*args)
+      (defined?(@dump_options) && get_options(@dump_options, *args)) || default_dump_options
     end
 
     def default_load_options
@@ -28,8 +28,8 @@ module MultiJson
 
     private
 
-    def get_options(options, *)
-      return handle_callable_options(options, *) if options_callable?(options)
+    def get_options(options, *args)
+      return handle_callable_options(options, *args) if options_callable?(options)
 
       handle_hashable_options(options)
     end
@@ -38,8 +38,8 @@ module MultiJson
       options.respond_to?(:call)
     end
 
-    def handle_callable_options(options, *)
-      options.arity.zero? ? options.call : options.call(*)
+    def handle_callable_options(options, *args)
+      options.arity.zero? ? options.call : options.call(*args)
     end
 
     def handle_hashable_options(options)

--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -20,7 +20,7 @@ module MultiJson
         end
       end
 
-      def fetch(key, &)
+      def fetch(key, &_block)
         @mutex.synchronize do
           return @cache[key] if @cache.key?(key)
         end

--- a/multi_json.gemspec
+++ b/multi_json.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.name = "multi_json"
   spec.require_path = "lib"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.0"
   spec.summary = "A common interface to multiple JSON libraries."
   spec.version = MultiJson::Version
 


### PR DESCRIPTION
Ref: https://github.com/sferik/multi_json/issues/9

While older rubies are EOL, some alternative implementations like JRuby may be a bit behind, but more importantly there isn't much point restricting older rubies unless it helps cleanup the code base significantly.