### PR TITLE
Add fast_jsonparser adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tmtags
 ## VIM
 *.swp
 
+## IDEA
+.idea
+
 ## PROJECT::GENERAL
 .yardoc
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ gem "gson", ">= 0.6", platforms: [:jruby], require: false
 gem "jrjackson", ">= 0.4.18", platforms: [:jruby], require: false
 gem "oj", "~> 3.0", platforms: %i[ruby windows], require: false
 gem "yajl-ruby", "~> 1.3", platforms: %i[ruby windows], require: false
+gem "fast_jsonparser", ">= 0.6", platforms: %i[ruby windows], require: false
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ MultiJSON falls back to [OkJson][], a simple, vendorable JSON parser.
 
 ## Supported JSON Engines
 
+- [FastJsonparser][fast_jsonparser] Fast JSON parser by Anil Maurya
 - [Oj][oj] Optimized JSON by Peter Ohler
 - [Yajl][yajl] Yet Another JSON Library by Brian Lopez
 - [JSON][json-gem] The default JSON gem with C-extensions (ships with Ruby 1.9+)
@@ -105,6 +106,7 @@ and Pavel Pravosud. See [LICENSE][] for details.
 [json-gem]: https://github.com/flori/json
 [license]: LICENSE.md
 [macruby]: http://www.macruby.org/
+[fast_jsonparser]: https://github.com/anilmaurya/fast_jsonparser
 [oj]: https://github.com/ohler55/oj
 [okjson]: https://github.com/kr/okjson
 [pvc]: http://docs.rubygems.org/read/chapter/16#page74

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ end
 desc "Run the full test suite"
 task spec: %w[
   base_spec
+  adapters:fast_jsonparser
   adapters:oj
   adapters:yajl
   adapters:json_gem

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,4 +1,8 @@
+libx = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(libx) unless $LOAD_PATH.include?(libx)
+
 require "oj"
+require "fast_jsonparser"
 require "multi_json"
 require "benchmark/ips"
 
@@ -7,5 +11,13 @@ MultiJson.use :oj
 Benchmark.ips do |x|
   x.time = 10
   x.warmup = 1
-  x.report { MultiJson.load(MultiJson.dump(a: 1, b: 2, c: 3)) }
+  x.report("oj") { MultiJson.load(MultiJson.dump(a: 1, b: 2, c: 3)) }
+end
+
+MultiJson.use :fast_jsonparser
+
+Benchmark.ips do |x|
+  x.time = 10
+  x.warmup = 1
+  x.report("fast_jsonparser") { MultiJson.load(MultiJson.dump(a: 1, b: 2, c: 3)) }
 end

--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -29,6 +29,7 @@ module MultiJson
   ALIASES = {"jrjackson" => "jr_jackson"}.freeze
 
   REQUIREMENT_MAP = {
+    fast_jsonparser: "fast_jsonparser",
     oj: "oj",
     yajl: "yajl",
     jr_jackson: "jrjackson",
@@ -69,6 +70,7 @@ module MultiJson
   # Set the JSON parser utilizing a symbol, string, or class.
   # Supported by default are:
   #
+  # * <tt>:fast_jsonparser</tt>
   # * <tt>:oj</tt>
   # * <tt>:json_gem</tt>
   # * <tt>:json_pure</tt>
@@ -143,6 +145,7 @@ module MultiJson
 
   # Checks for already loaded adapters and returns the first match
   def loaded_adapter
+    return :fast_jsonparser if defined?(::FastJsonparser)
     return :oj if defined?(::Oj)
     return :yajl if defined?(::Yajl)
     return :jr_jackson if defined?(::JrJackson)

--- a/lib/multi_json/adapters/fast_jsonparser.rb
+++ b/lib/multi_json/adapters/fast_jsonparser.rb
@@ -1,0 +1,49 @@
+require "fast_jsonparser"
+require "oj"
+require_relative "../adapter"
+
+module MultiJson
+  module Adapters
+    # Use the fast_jsonparser library for loading and Oj for dumping.
+    class FastJsonparser < Adapter
+      defaults :load, symbolize_keys: false
+      defaults :dump, mode: :compat, time_format: :ruby, use_to_json: true
+
+      ParseError = ::FastJsonparser::Error
+
+      def load(string, options = {})
+        ::FastJsonparser.parse(string, symbolize_keys: options[:symbolize_keys])
+      end
+
+      OJ_VERSION = ::Oj::VERSION
+      OJ_V2 = OJ_VERSION.start_with?("2.")
+      OJ_V3 = OJ_VERSION.start_with?("3.")
+      private_constant :OJ_VERSION, :OJ_V2, :OJ_V3
+
+      if OJ_V3
+        PRETTY_STATE_PROTOTYPE = {
+          indent: "  ",
+          space: " ",
+          space_before: "",
+          object_nl: "\n",
+          array_nl: "\n",
+          ascii_only: false
+        }.freeze
+        private_constant :PRETTY_STATE_PROTOTYPE
+      end
+
+      def dump(object, options = {})
+        if OJ_V2
+          options[:indent] = 2 if options[:pretty]
+          options[:indent] = options[:indent].to_i if options[:indent]
+        elsif OJ_V3
+          options.merge!(PRETTY_STATE_PROTOTYPE.dup) if options.delete(:pretty)
+        else
+          raise "Unsupported Oj version: #{::Oj::VERSION}"
+        end
+
+        ::Oj.dump(object, options)
+      end
+    end
+  end
+end

--- a/spec/multi_json/adapters/fast_jsonparser_spec.rb
+++ b/spec/multi_json/adapters/fast_jsonparser_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+return unless RSpec.configuration.fast_jsonparser?
+
+require "shared/adapter"
+require "multi_json/adapters/fast_jsonparser"
+
+RSpec.describe MultiJson::Adapters::FastJsonparser, :fast_jsonparser do
+  it_behaves_like "an adapter", described_class
+end

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MultiJson do
     it "default_adapter tries to require each adapter in turn and does not assume :json_gem is already loaded" do
       expect(JSON::JSON_LOADED).to be_truthy
 
-      undefine_constants :Oj, :Yajl, :Gson, :JrJackson do
+      undefine_constants :Oj, :Yajl, :Gson, :JrJackson, :FastJsonparser do
         # simulate that the json_gem is not loaded
         ext = defined?(JSON::Ext::Parser) ? JSON::Ext.send(:remove_const, :Parser) : nil
         begin
@@ -92,7 +92,9 @@ RSpec.describe MultiJson do
     end
 
     it "defaults to the best available gem" do
-      if config.java? && config.jrjackson?
+      if config.fast_jsonparser?
+        expect(described_class.adapter.to_s).to eq("MultiJson::Adapters::FastJsonparser")
+      elsif config.java? && config.jrjackson?
         expect(described_class.adapter.to_s).to eq("MultiJson::Adapters::JrJackson")
       elsif config.java? && config.json?
         expect(described_class.adapter.to_s).to eq("MultiJson::Adapters::JsonGem")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
   config.add_setting :ok_json, default: loaded_specs.key?("ok_json")
   config.add_setting :oj, default: loaded_specs.key?("oj")
   config.add_setting :yajl, default: loaded_specs.key?("yajl")
+  config.add_setting :fast_jsonparser, default: loaded_specs.key?("fast_jsonparser")
 
   config.filter_run_excluding(:jrjackson) unless config.jrjackson?
   config.filter_run_excluding(:json) unless config.json?
@@ -24,6 +25,7 @@ RSpec.configure do |config|
   config.filter_run_excluding(:ok_json) unless config.ok_json?
   config.filter_run_excluding(:oj) unless config.oj?
   config.filter_run_excluding(:yajl) unless config.yajl?
+  config.filter_run_excluding(:fast_jsonparser) unless config.fast_jsonparser?
 
   unless config.java?
     config.filter_run_excluding(:java)
@@ -71,7 +73,7 @@ end
 
 def simulate_no_adapters(&block)
   break_requirements do
-    undefine_constants :JSON, :Oj, :Yajl, :Gson, :JrJackson, &block
+    undefine_constants :JSON, :Oj, :Yajl, :Gson, :JrJackson, :FastJsonparser, &block
   end
 end
 


### PR DESCRIPTION
## Summary
- add `fast_jsonparser` to dev dependencies
- implement `fast_jsonparser` adapter
- integrate adapter into load logic and documentation
- benchmark using the new adapter
- cover adapter with specs and adjust spec helper

## Testing
- `bundle exec rake`
- `bundle exec standardrb`

------
https://chatgpt.com/codex/tasks/task_e_687af933c724832785ccced1dcf14f52