### PR TITLE
Remove json_pure adapter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,6 @@ task spec: %w[
   adapters:oj
   adapters:yajl
   adapters:json_gem
-  adapters:json_pure
   adapters:ok_json
   adapters:gson
   adapters:jr_jackson

--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -34,8 +34,7 @@ module MultiJson
     yajl: "yajl",
     jr_jackson: "jrjackson",
     json_gem: "json",
-    gson: "gson",
-    json_pure: "json"
+    gson: "gson"
   }.freeze
 
   # The default adapter based on what you currently
@@ -73,7 +72,6 @@ module MultiJson
   # * <tt>:fast_jsonparser</tt>
   # * <tt>:oj</tt>
   # * <tt>:json_gem</tt>
-  # * <tt>:json_pure</tt>
   # * <tt>:ok_json</tt>
   # * <tt>:yajl</tt>
   # * <tt>:gson</tt> (JRuby only)

--- a/lib/multi_json/adapters/json_pure.rb
+++ b/lib/multi_json/adapters/json_pure.rb
@@ -1,7 +1,0 @@
-require_relative "json_gem"
-
-module MultiJson
-  module Adapters
-    JsonPure = JsonGem
-  end
-end

--- a/spec/multi_json/adapters/json_pure_spec.rb
+++ b/spec/multi_json/adapters/json_pure_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-require "shared/adapter"
-require "shared/json_common_adapter"
-require "multi_json/adapters/json_pure"
-
-RSpec.describe MultiJson::Adapters::JsonPure, :json_pure do
-  it_behaves_like "an adapter", described_class
-  it_behaves_like "JSON-like adapter", described_class
-end

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -144,30 +144,30 @@ RSpec.describe MultiJson do
 
   context "with one-shot parser" do
     it "uses the defined parser just for the call" do
-      expect(MultiJson::Adapters::JsonPure).to receive(:dump).once.and_return("dump_something")
-      expect(MultiJson::Adapters::JsonPure).to receive(:load).once.and_return("load_something")
+      expect(MultiJson::Adapters::OkJson).to receive(:dump).once.and_return("dump_something")
+      expect(MultiJson::Adapters::OkJson).to receive(:load).once.and_return("load_something")
       described_class.use :json_gem
-      expect(described_class.dump("", adapter: :json_pure)).to eq("dump_something")
-      expect(described_class.load("", adapter: :json_pure)).to eq("load_something")
+      expect(described_class.dump("", adapter: :ok_json)).to eq("dump_something")
+      expect(described_class.load("", adapter: :ok_json)).to eq("load_something")
       expect(described_class.adapter).to eq(MultiJson::Adapters::JsonGem)
     end
   end
 
   it "can set adapter for a block" do
-    described_class.use :ok_json
-    described_class.with_adapter(:json_pure) do
-      described_class.with_engine(:json_gem) do
-        expect(described_class.adapter).to eq(MultiJson::Adapters::JsonGem)
+    described_class.use :oj
+    described_class.with_adapter(:json_gem) do
+      described_class.with_engine(:ok_json) do
+        expect(described_class.adapter).to eq(MultiJson::Adapters::OkJson)
       end
-      expect(described_class.adapter).to eq(MultiJson::Adapters::JsonPure)
+      expect(described_class.adapter).to eq(MultiJson::Adapters::JsonGem)
     end
-    expect(described_class.adapter).to eq(MultiJson::Adapters::OkJson)
+    expect(described_class.adapter).to eq(MultiJson::Adapters::Oj)
   end
 
   it "restores adapter after an exception" do
     described_class.use :json_gem
     expect do
-      described_class.with_adapter(:json_pure) { raise StandardError }
+      described_class.with_adapter(:oj) { raise StandardError }
     rescue
     end.not_to change(described_class, :adapter)
   end

--- a/spec/shared/adapter.rb
+++ b/spec/shared/adapter.rb
@@ -13,11 +13,6 @@ shared_examples_for "an adapter" do |adapter|
   end
 
   describe ".dump" do
-    let(:json_pure) do
-      Kernel.const_get("MultiJson::Adapters::JsonPure")
-    rescue
-      nil
-    end
 
     describe "#dump_options" do
       before { MultiJson.dump_options = MultiJson.adapter.dump_options = {} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ RSpec.configure do |config|
   config.add_setting :java, default: RUBY_PLATFORM == "java"
   config.add_setting :gson, default: loaded_specs.key?("gson")
   config.add_setting :json, default: loaded_specs.key?("json")
-  config.add_setting :json_pure, default: loaded_specs.key?("json_pure")
   config.add_setting :jrjackson, default: loaded_specs.key?("jrjackson")
   config.add_setting :ok_json, default: loaded_specs.key?("ok_json")
   config.add_setting :oj, default: loaded_specs.key?("oj")
@@ -21,7 +20,6 @@ RSpec.configure do |config|
 
   config.filter_run_excluding(:jrjackson) unless config.jrjackson?
   config.filter_run_excluding(:json) unless config.json?
-  config.filter_run_excluding(:json_pure) unless config.json_pure?
   config.filter_run_excluding(:ok_json) unless config.ok_json?
   config.filter_run_excluding(:oj) unless config.oj?
   config.filter_run_excluding(:yajl) unless config.yajl?


### PR DESCRIPTION
## Summary
- remove `json_pure` adapter implementation and spec
- drop mentions of `json_pure` from MultiJson configuration and task list
- adjust specs to use other adapters

## Testing
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_687b0b4da9508327a551719354386440