### PR TITLE
Update adapter defaults handling

### DIFF
--- a/lib/multi_json/adapter.rb
+++ b/lib/multi_json/adapter.rb
@@ -10,9 +10,18 @@ module MultiJson
       BLANK_RE = /\A\s*\z/
       private_constant :BLANK_RE
 
+      def inherited(subclass)
+        super
+        if instance_variable_defined?(:@default_load_options)
+          subclass.instance_variable_set(:@default_load_options, @default_load_options)
+        end
+        if instance_variable_defined?(:@default_dump_options)
+          subclass.instance_variable_set(:@default_dump_options, @default_dump_options)
+        end
+      end
+
       def defaults(action, value)
-        value.freeze
-        define_singleton_method("default_#{action}_options") { value }
+        instance_variable_set("@default_#{action}_options", value.freeze)
       end
 
       def load(string, options = {})


### PR DESCRIPTION
## Summary
- remove singleton methods for Adapter defaults
- copy defaults on subclass inheritance

## Testing
- `bundle exec rspec` *(fails: undefined method `fetch` for MultiJson::OptionsCache)*

------
https://chatgpt.com/codex/tasks/task_e_687b109bc1b88327971f147efb8b1d1b