### PR TITLE
Fix pretty JSON with json gem and ActiveSupport

### DIFF
--- a/lib/multi_json/adapters/json_gem.rb
+++ b/lib/multi_json/adapters/json_gem.rb
@@ -27,7 +27,7 @@ module MultiJson
       def dump(object, options = {})
         options.merge!(PRETTY_STATE_PROTOTYPE) if options.delete(:pretty)
 
-        object.to_json(options)
+        ::JSON.generate(object, options)
       end
     end
   end

--- a/spec/shared/json_common_adapter.rb
+++ b/spec/shared/json_common_adapter.rb
@@ -7,12 +7,12 @@ shared_examples_for "JSON-like adapter" do |adapter|
     describe "with :pretty option set to true" do
       it "passes default pretty options" do
         object = "foo"
-        expect(object).to receive(:to_json).with({
+        expect(::JSON).to receive(:generate).with(object, {
           indent: "  ",
           space: " ",
           object_nl: "\n",
           array_nl: "\n"
-        })
+        }).and_call_original
         MultiJson.dump(object, pretty: true)
       end
     end
@@ -20,7 +20,7 @@ shared_examples_for "JSON-like adapter" do |adapter|
     describe "with :indent option" do
       it "passes it on dump" do
         object = "foo"
-        expect(object).to receive(:to_json).with({indent: "\t"})
+        expect(::JSON).to receive(:generate).with(object, {indent: "\t"}).and_call_original
         MultiJson.dump(object, indent: "\t")
       end
     end


### PR DESCRIPTION
## Summary
- ensure pretty options respected when ActiveSupport overrides `to_json`
- update specs for json_gem adapter

## Testing
- `bundle exec rspec spec`

------
https://chatgpt.com/codex/tasks/task_e_687b192ab5988327abfc591d97284c8d