### PR TITLE
Remove conditional subject in shared options spec

### DIFF
--- a/spec/shared/options.rb
+++ b/spec/shared/options.rb
@@ -1,9 +1,5 @@
 shared_examples_for "has options" do |object|
-  if object.respond_to?(:call)
-    subject { object.call }
-  else
-    subject { object }
-  end
+  subject { object.respond_to?(:call) ? object.call : object }
 
   describe "dump options" do
     before do


### PR DESCRIPTION
## Summary
- refactor subject initialization in `spec/shared/options.rb`
- tests continue to pass

## Testing
- `bundle exec rake base_spec`
- `bundle exec rake adapters:fast_jsonparser`
- `bundle exec rake adapters:oj`
- `bundle exec rake adapters:yajl`
- `bundle exec rake adapters:json_gem`
- `bundle exec rake adapters:ok_json`
- `bundle exec rake adapters:gson`
- `bundle exec rake adapters:jr_jackson`
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_687b1ed2bf348327a70dd9ce3a0c38e2