### PR TITLE
Fix rubocop issue

### DIFF
--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe MultiJson do
 
       undefine_constants :Oj, :Yajl, :Gson, :JrJackson, :FastJsonparser do
         # simulate that the json_gem is not loaded
-        ext = defined?(JSON::Ext::Parser) ? JSON::Ext.send(:remove_const, :Parser) : nil
+        ext = JSON::Ext::Parser if defined?(JSON::Ext::Parser)
+        hide_const("JSON::Ext::Parser")
         begin
           expect(described_class).to receive(:require)
           described_class.default_adapter


### PR DESCRIPTION
## Summary
- use `hide_const` instead of removing `JSON::Ext::Parser` constant in specs

## Testing
- `bundle exec rubocop | tail -n 2`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687b2d3bf2c88327b97e2383f5a5af3d