### PR TITLE
Fix Rubocop issue via hide_const

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -20,12 +20,16 @@ module MultiJson
         end
       end
 
-      def fetch(key)
+      def fetch(key, default = nil)
         @mutex.synchronize do
           return @cache[key] if @cache.key?(key)
         end
 
-        value = yield
+        value = if block_given?
+          yield
+        else
+          default
+        end
 
         @mutex.synchronize { store_value(key, value) }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,18 +40,9 @@ ensure
 end
 
 def undefine_constants(*consts)
-  values = {}
-  consts.each do |const|
-    if Object.const_defined?(const)
-      values[const] = Object.const_get(const)
-      Object.send :remove_const, const
-    end
-  end
-
-  yield
-ensure
-  values.each do |const, value|
-    Object.const_set const, value
+  RSpec::Mocks.with_temporary_scope do
+    consts.each { |const| hide_const(const.to_s) }
+    yield
   end
 end
 


### PR DESCRIPTION
## Summary
- use `hide_const` inside `undefine_constants` to avoid using `remove_const`
- support default values in `OptionsCache::Store#fetch`

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687b310bc0c483278370ab974410c841