### PR TITLE
Fix Rubocop RSpec/MessageSpies issue

### DIFF
--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -39,14 +39,16 @@ RSpec.describe MultiJson do
     end
 
     it "prints a warning" do
-      expect(Kernel).to receive(:warn).with(/warning/i)
+      allow(Kernel).to receive(:warn)
       described_class.default_adapter
+      expect(Kernel).to have_received(:warn).with(/warning/i)
     end
 
     it "warns only once" do
-      expect(Kernel).to receive(:warn).once
+      allow(Kernel).to receive(:warn)
       described_class.default_adapter
       described_class.default_adapter
+      expect(Kernel).to have_received(:warn).once
     end
   end
 
@@ -193,8 +195,9 @@ RSpec.describe MultiJson do
     end
 
     it "is deprecated" do
-      expect(Kernel).to receive(:warn).with(/deprecated/i)
+      allow(Kernel).to receive(:warn)
       silence_warnings { described_class.default_options = {foo: "bar"} }
+      expect(Kernel).to have_received(:warn).with(/deprecated/i)
     end
 
     it "sets both load and dump options" do


### PR DESCRIPTION
## Summary
- clean up specs to use `have_received` instead of `receive`

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687b34c089cc832792421b7ddd0fa33b