### PR TITLE
Refactor MultiJson module

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -6,32 +6,8 @@ require_relative "multi_json/options_cache"
 require_relative "multi_json/adapter_selector"
 
 module MultiJson
-  include Options
   extend Options
   extend AdapterSelector
-
-  Options.private_instance_methods(false).each { |m| singleton_class.send(:public, m) }
-  AdapterSelector.private_instance_methods(false).each { |m| singleton_class.send(:public, m) }
-
-  module_function
-
-  def default_options=(value)
-    Kernel.warn "MultiJson.default_options setter is deprecated\nUse MultiJson.load_options and MultiJson.dump_options instead"
-
-    self.load_options = self.dump_options = value
-  end
-
-  def default_options
-    Kernel.warn "MultiJson.default_options is deprecated\nUse MultiJson.load_options or MultiJson.dump_options instead"
-
-    load_options
-  end
-
-  %w[cached_options reset_cached_options!].each do |method_name|
-    define_method method_name do |*|
-      Kernel.warn "MultiJson.#{method_name} method is deprecated and no longer used."
-    end
-  end
 
   ALIASES = {"jrjackson" => "jr_jackson"}.freeze
 
@@ -45,60 +21,73 @@ module MultiJson
   }.freeze
 
   class << self
+    public(*AdapterSelector.private_instance_methods(false))
+
+    def default_options=(value)
+      Kernel.warn "MultiJson.default_options setter is deprecated\nUse MultiJson.load_options and MultiJson.dump_options instead"
+      self.load_options = self.dump_options = value
+    end
+
+    def default_options
+      Kernel.warn "MultiJson.default_options is deprecated\nUse MultiJson.load_options or MultiJson.dump_options instead"
+      load_options
+    end
+
+    %w[cached_options reset_cached_options!].each do |method_name|
+      define_method method_name do |*|
+        Kernel.warn "MultiJson.#{method_name} method is deprecated and no longer used."
+      end
+    end
+
     alias_method :default_engine, :default_adapter
-  end
 
-  # Get the current adapter class.
-  def adapter
-    return @adapter if defined?(@adapter) && @adapter
+    def adapter
+      return @adapter if defined?(@adapter) && @adapter
 
-    use nil # load default adapter
+      use nil
 
-    @adapter
-  end
-  alias_method :engine, :adapter
-
-  def use(new_adapter)
-    @adapter = load_adapter(new_adapter)
-  ensure
-    OptionsCache.reset
-  end
-  alias_method :adapter=, :use
-  alias_method :engine=, :use
-  module_function :adapter=, :engine=
-
-  def load(string, options = {})
-    adapter = current_adapter(options)
-    begin
-      adapter.load(string, options)
-    rescue adapter::ParseError => e
-      raise(ParseError.build(e, string), cause: e)
+      @adapter
     end
-  end
-  alias_method :decode, :load
+    alias_method :engine, :adapter
 
-  def current_adapter(options = {})
-    if (new_adapter = options[:adapter])
-      load_adapter(new_adapter)
-    else
-      adapter
+    def use(new_adapter)
+      @adapter = load_adapter(new_adapter)
+    ensure
+      OptionsCache.reset
     end
-  end
+    alias_method :adapter=, :use
+    alias_method :engine=, :use
 
-  # Encodes a Ruby object as JSON.
-  def dump(object, options = {})
-    current_adapter(options).dump(object, options)
-  end
-  alias_method :encode, :dump
+    def load(string, options = {})
+      adapter = current_adapter(options)
+      begin
+        adapter.load(string, options)
+      rescue adapter::ParseError => e
+        raise(ParseError.build(e, string), cause: e)
+      end
+    end
+    alias_method :decode, :load
 
-  #  Executes passed block using specified adapter.
-  def with_adapter(new_adapter)
-    old_adapter = adapter
-    self.adapter = new_adapter
-    yield
-  ensure
-    self.adapter = old_adapter
+    def current_adapter(options = {})
+      if (new_adapter = options[:adapter])
+        load_adapter(new_adapter)
+      else
+        adapter
+      end
+    end
+
+    def dump(object, options = {})
+      current_adapter(options).dump(object, options)
+    end
+    alias_method :encode, :dump
+
+    def with_adapter(new_adapter)
+      old_adapter = adapter
+      self.adapter = new_adapter
+      yield
+    ensure
+      self.adapter = old_adapter
+    end
+    alias_method :with_engine, :with_adapter
   end
-  alias_method :with_engine, :with_adapter
-  module_function :with_engine
 end


### PR DESCRIPTION
## Summary
- remove `include Options` and publicizing internal helpers
- use a single `class << self` block for all class methods
- keep adapter selector utilities public

## Testing
- `bundle install`
- `bundle exec rake base_spec`
- `bundle exec rake adapters:oj`

------
https://chatgpt.com/codex/tasks/task_e_687bc88dc99c8327adac5bcf4034a745