### PR TITLE
Expose cache size constant

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -1,14 +1,12 @@
 module MultiJson
   module OptionsCache
-    class Store
-      # Normally MultiJson is used with a few option sets for both dump/load
-      # methods. When options are generated dynamically though, every call would
-      # cause a cache miss and the cache would grow indefinitely. To prevent
-      # this, we just reset the cache every time the number of keys outgrows
-      # 1000.
-      MAX_CACHE_SIZE = 1000
-      private_constant :MAX_CACHE_SIZE
+    # Normally MultiJson is used with a few option sets for both dump/load
+    # methods. When options are generated dynamically though, every call would
+    # cause a cache miss and the cache would grow indefinitely. To prevent this,
+    # we reset the cache every time the number of keys outgrows 1000.
+    MAX_CACHE_SIZE = 1000
 
+    class Store
       def initialize
         @cache = {}
         @mutex = Mutex.new

--- a/spec/multi_json/options_cache_spec.rb
+++ b/spec/multi_json/options_cache_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MultiJson::OptionsCache do
   before do
     described_class.reset
-    max = described_class::Store.const_get(:MAX_CACHE_SIZE)
+    max = described_class::MAX_CACHE_SIZE
 
     (max + 1).times do |i|
       described_class.dump.fetch(key: i) { {foo: i} }


### PR DESCRIPTION
## Summary
- expose `MAX_CACHE_SIZE` at module level so it is easier to access
- adjust spec to use the new constant

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_687bcb6ad3248327be5162a9837c95ed