### PR TITLE
Improve OptionsCache thread safety

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -21,11 +21,10 @@ module MultiJson
       def fetch(key, default = nil)
         @mutex.synchronize do
           return @cache[key] if @cache.key?(key)
+
+          value = block_given? ? yield : default
+          store_value(key, value)
         end
-
-        value = block_given? ? yield : default
-
-        @mutex.synchronize { store_value(key, value) }
       end
 
       private

--- a/spec/multi_json/options_cache_spec.rb
+++ b/spec/multi_json/options_cache_spec.rb
@@ -25,4 +25,11 @@ describe MultiJson::OptionsCache do
 
     expect(described_class.load.fetch(:foo, :baz)).to eq(:baz)
   end
+
+  it "executes block only once per key in concurrent access" do
+    described_class.reset
+    counter = 0
+    Array.new(5) { Thread.new { described_class.dump.fetch(:foo) { counter += 1 } } }.each(&:join)
+    expect(counter).to eq(1)
+  end
 end


### PR DESCRIPTION
## Summary
- make `OptionsCache::Store#fetch` compute values while holding the mutex
- ensure block in `OptionsCache::Store#fetch` executes only once even with concurrent callers
- add a concurrency spec for the options cache

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687d0a638ad483279268762333541b0f