### PR TITLE
Refactor Oj-based adapters

### DIFF
--- a/lib/multi_json/adapters/fast_jsonparser.rb
+++ b/lib/multi_json/adapters/fast_jsonparser.rb
@@ -1,11 +1,13 @@
 require "fast_jsonparser"
 require "oj"
 require_relative "../adapter"
+require_relative "oj_common"
 
 module MultiJson
   module Adapters
     # Use the FastJsonparser library to load and Oj to dump.
     class FastJsonparser < Adapter
+      include OjCommon
       defaults :load, symbolize_keys: false
       defaults :dump, mode: :compat, time_format: :ruby, use_to_json: true
 
@@ -15,34 +17,8 @@ module MultiJson
         ::FastJsonparser.parse(string, symbolize_keys: options[:symbolize_keys])
       end
 
-      OJ_VERSION = ::Oj::VERSION
-      OJ_V2 = OJ_VERSION.start_with?("2.")
-      OJ_V3 = OJ_VERSION.start_with?("3.")
-      private_constant :OJ_VERSION, :OJ_V2, :OJ_V3
-
-      if OJ_V3
-        PRETTY_STATE_PROTOTYPE = {
-          indent: "  ",
-          space: " ",
-          space_before: "",
-          object_nl: "\n",
-          array_nl: "\n",
-          ascii_only: false
-        }.freeze
-        private_constant :PRETTY_STATE_PROTOTYPE
-      end
-
       def dump(object, options = {})
-        if OJ_V2
-          options[:indent] = 2 if options[:pretty]
-          options[:indent] = options[:indent].to_i if options[:indent]
-        elsif OJ_V3
-          options.merge!(PRETTY_STATE_PROTOTYPE.dup) if options.delete(:pretty)
-        else
-          raise "Unsupported Oj version: #{::Oj::VERSION}"
-        end
-
-        ::Oj.dump(object, options)
+        ::Oj.dump(object, prepare_dump_options(options))
       end
     end
   end

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -1,10 +1,12 @@
 require "oj"
 require_relative "../adapter"
+require_relative "oj_common"
 
 module MultiJson
   module Adapters
     # Use the Oj library to dump/load.
     class Oj < Adapter
+      include OjCommon
       defaults :load, mode: :strict, symbolize_keys: false
       defaults :dump, mode: :compat, time_format: :ruby, use_to_json: true
 
@@ -29,34 +31,8 @@ module MultiJson
         ::Oj.load(string, options)
       end
 
-      OJ_VERSION = ::Oj::VERSION
-      OJ_V2 = OJ_VERSION.start_with?("2.")
-      OJ_V3 = OJ_VERSION.start_with?("3.")
-      private_constant :OJ_VERSION, :OJ_V2, :OJ_V3
-
-      if OJ_V3
-        PRETTY_STATE_PROTOTYPE = {
-          indent: "  ",
-          space: " ",
-          space_before: "",
-          object_nl: "\n",
-          array_nl: "\n",
-          ascii_only: false
-        }.freeze
-        private_constant :PRETTY_STATE_PROTOTYPE
-      end
-
       def dump(object, options = {})
-        if OJ_V2
-          options[:indent] = 2 if options[:pretty]
-          options[:indent] = options[:indent].to_i if options[:indent]
-        elsif OJ_V3
-          options.merge!(PRETTY_STATE_PROTOTYPE.dup) if options.delete(:pretty)
-        else
-          raise "Unsupported Oj version: #{::Oj::VERSION}"
-        end
-
-        ::Oj.dump(object, options)
+        ::Oj.dump(object, prepare_dump_options(options))
       end
     end
   end

--- a/lib/multi_json/adapters/oj_common.rb
+++ b/lib/multi_json/adapters/oj_common.rb
@@ -1,0 +1,37 @@
+module MultiJson
+  module Adapters
+    module OjCommon
+      OJ_VERSION = ::Oj::VERSION
+      OJ_V2 = OJ_VERSION.start_with?("2.")
+      OJ_V3 = OJ_VERSION.start_with?("3.")
+      private_constant :OJ_VERSION, :OJ_V2, :OJ_V3
+
+      if OJ_V3
+        PRETTY_STATE_PROTOTYPE = {
+          indent: "  ",
+          space: " ",
+          space_before: "",
+          object_nl: "\n",
+          array_nl: "\n",
+          ascii_only: false
+        }.freeze
+        private_constant :PRETTY_STATE_PROTOTYPE
+      end
+
+      private
+
+      def prepare_dump_options(options)
+        if OJ_V2
+          options[:indent] = 2 if options[:pretty]
+          options[:indent] = options[:indent].to_i if options[:indent]
+        elsif OJ_V3
+          options.merge!(PRETTY_STATE_PROTOTYPE.dup) if options.delete(:pretty)
+        else
+          raise "Unsupported Oj version: #{::Oj::VERSION}"
+        end
+
+        options
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- reduce duplication in Oj-based adapters
- pull shared Oj options logic into a new `OjCommon` module

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687e4bb07794832797d68eac85dc4902