### PR TITLE
Use tempfile for json gem pretty spec

### DIFF
--- a/spec/multi_json/adapters/json_gem_spec.rb
+++ b/spec/multi_json/adapters/json_gem_spec.rb
@@ -4,6 +4,7 @@ require "shared/json_common_adapter"
 require "multi_json/adapters/json_gem"
 require "open3"
 require "rbconfig"
+require "tempfile"
 
 RSpec.describe MultiJson::Adapters::JsonGem, :json do
   it_behaves_like "an adapter", described_class
@@ -13,21 +14,22 @@ RSpec.describe MultiJson::Adapters::JsonGem, :json do
     let(:data) { {a: 1, b: 2, c: {d: {f: 2}}} }
     let(:expected_output) { "#{JSON.pretty_generate(data)}\n" }
 
-    let(:script) do
-      <<~RUBY
-        $LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
-        require "multi_json"
-        require "multi_json/adapters/json_gem"
-        require "active_support/json"
-
-        data = {a: 1, b: 2, c: {d: {f: 2}}}
-
-        puts MultiJson.dump(data, pretty: true, adapter: :json_gem)
-      RUBY
-    end
-
     it "prettifies output when :pretty is true" do
-      output, status = Open3.capture2(RbConfig.ruby, "-e", script)
+      output, status = Tempfile.create(["active_support_json_pretty", ".rb"]) do |file|
+        file.write(<<~RUBY)
+          $LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
+          require "multi_json"
+          require "multi_json/adapters/json_gem"
+          require "active_support/json"
+
+          data = {a: 1, b: 2, c: {d: {f: 2}}}
+
+          puts MultiJson.dump(data, pretty: true, adapter: :json_gem)
+        RUBY
+        file.flush
+
+        Open3.capture2(RbConfig.ruby, file.path)
+      end
 
       expect([status.success?, output]).to eq([true, expected_output])
     end


### PR DESCRIPTION
## Summary
- run the active_support pretty output check from a temporary script file
- require tempfile and execute the script file to avoid -e quoting issues on JRuby

## Testing
- bundle exec rspec spec/multi_json/adapters/json_gem_spec.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df72b97fc832785bcc8efef445b2c)