### PR TITLE
Refine json_gem pretty printing and specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "activesupport", require: false
 gem "json", "~> 2.0", require: false
 
 gem "rake", ">= 13.1"

--- a/lib/multi_json/adapters/json_gem.rb
+++ b/lib/multi_json/adapters/json_gem.rb
@@ -25,9 +25,14 @@ module MultiJson
       end
 
       def dump(object, options = {})
-        options.merge!(PRETTY_STATE_PROTOTYPE) if options.delete(:pretty)
+        opts = options.dup
 
-        object.to_json(options)
+        if opts.delete(:pretty)
+          opts = PRETTY_STATE_PROTOTYPE.merge(opts)
+          return ::JSON.pretty_generate(object, opts)
+        end
+
+        ::JSON.generate(object, opts)
       end
     end
   end

--- a/spec/multi_json/adapters/json_gem_spec.rb
+++ b/spec/multi_json/adapters/json_gem_spec.rb
@@ -2,8 +2,45 @@ require "spec_helper"
 require "shared/adapter"
 require "shared/json_common_adapter"
 require "multi_json/adapters/json_gem"
+require "open3"
+require "rbconfig"
+require "tempfile"
 
 RSpec.describe MultiJson::Adapters::JsonGem, :json do
   it_behaves_like "an adapter", described_class
   it_behaves_like "JSON-like adapter", described_class
+
+  context "when active_support/json is loaded" do
+    let(:data) { {a: 1, b: 2, c: {d: {f: 2}}} }
+    let(:expected_output) { "#{JSON.pretty_generate(data)}\n" }
+
+    let(:script) do
+      <<~RUBY
+        $LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
+        require "multi_json"
+        require "multi_json/adapters/json_gem"
+        require "active_support/json"
+
+        data = {a: 1, b: 2, c: {d: {f: 2}}}
+
+        puts MultiJson.dump(data, pretty: true, adapter: :json_gem)
+      RUBY
+    end
+
+    def run_script(script_content)
+      Tempfile.create(["multi_json_json_gem", ".rb"]) do |file|
+        file.write(script_content)
+        file.flush
+        file.close
+
+        Open3.capture2(RbConfig.ruby, file.path)
+      end
+    end
+
+    it "prettifies output when :pretty is true" do
+      output, status = run_script(script)
+
+      expect([status.success?, output]).to eq([true, expected_output])
+    end
+  end
 end

--- a/spec/shared/json_common_adapter.rb
+++ b/spec/shared/json_common_adapter.rb
@@ -7,21 +7,28 @@ shared_examples_for "JSON-like adapter" do |adapter|
     describe "with :pretty option set to true" do
       it "passes default pretty options" do
         object = "foo"
-        expect(object).to receive(:to_json).with({
-          indent: "  ",
-          space: " ",
-          object_nl: "\n",
-          array_nl: "\n"
-        })
+        options = {indent: "  ", space: " ", object_nl: "\n", array_nl: "\n"}
+        allow(JSON).to receive(:pretty_generate).and_call_original
         MultiJson.dump(object, pretty: true)
+        expect(JSON).to have_received(:pretty_generate).with(object, options)
+      end
+
+      it "retains pretty formatting when options are cached" do
+        object = {foo: "bar"}
+        pretty_output = JSON.pretty_generate(object)
+
+        outputs = 2.times.map { MultiJson.dump(object, pretty: true) }
+
+        expect(outputs).to all(eq(pretty_output))
       end
     end
 
     describe "with :indent option" do
       it "passes it on dump" do
         object = "foo"
-        expect(object).to receive(:to_json).with({indent: "\t"})
+        allow(JSON).to receive(:generate).and_call_original
         MultiJson.dump(object, indent: "\t")
+        expect(JSON).to have_received(:generate).with(object, {indent: "\t"})
       end
     end
   end


### PR DESCRIPTION
## Summary
- update the json gem adapter to duplicate options, handle pretty formatting via JSON.pretty_generate, and rely on JSON.generate for other dumps
- add activesupport to the Gemfile and expand adapter specs to cover cached pretty formatting using isolated scripts and tempfiles
- align shared adapter specs with the json adapter’s generate-based implementation for indent handling

## Testing
- bundle exec rspec spec/multi_json/adapters/json_gem_spec.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfd9753008327870ef1c4a0e2fbd8)